### PR TITLE
Bump clamav version to 0.100.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-clamav/clamav-0.99.4.tar.gz:
-  size: 16083015
-  object_id: 662a4ebb-fb39-4fa8-46b0-5def9fa3183b
-  sha: 31f91cb63329385325821a03db46e7001dc40fa2
+clamav/clamav-0.100.1.tar.gz:
+  size: 16154415
+  sha: fb989218e68dd3d171ef23f45a19c0d09360eab1

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 clamav/clamav-0.100.1.tar.gz:
   size: 16154415
+  object_id: 9f793ec4-3908-406d-4b9a-431bff30f2e8
   sha: fb989218e68dd3d171ef23f45a19c0d09360eab1

--- a/jobs/clamav/templates/conf/clamd.conf.erb
+++ b/jobs/clamav/templates/conf/clamd.conf.erb
@@ -31,7 +31,6 @@ Foreground false
 Debug false
 LeaveTemporaryFiles false
 User root
-AllowSupplementaryGroups false
 Bytecode true
 BytecodeSecurity TrustSigned
 BytecodeTimeout 60000
@@ -68,5 +67,4 @@ OnAccessMountPath /var/vcap/data
 OnAccessMountPath /var/vcap/store
 OnAccessDisableDDD false
 OnAccessPrevention false
-StatsEnabled false
 TemporaryDirectory /var/vcap/data/tmp

--- a/jobs/clamav/templates/conf/freshclam.conf.erb
+++ b/jobs/clamav/templates/conf/freshclam.conf.erb
@@ -7,7 +7,6 @@ LogRotate true
 PidFile /var/vcap/sys/run/clamav/freshclam.pid
 DatabaseDirectory /var/vcap/packages/clamav/database
 Foreground false
-AllowSupplementaryGroups false
 UpdateLogFile /var/vcap/sys/log/clamav/freshclam.log
 DatabaseOwner root
 Checks 24
@@ -24,8 +23,5 @@ OnErrorExecute /var/vcap/jobs/clamav/bin/database_error.sh
 OnOutdatedExecute /var/vcap/jobs/clamav/bin/database_outdated.sh
 ConnectTimeout 10
 ReceiveTimeout 30
-SubmitDetectionStats false
-DetectionStatsCountry false
-DetectionStatsHostID false
 SafeBrowsing false
 Bytecode true


### PR DESCRIPTION
I believe that this is ready to go.  I deployed it in the development elasticache-broker deployment and saw it emit the EICAR warning in it's logs when I put it in place.  It should still be there if you'd like to check it out.
