### PR TITLE
Exclude bosh packages dirs causing false postive results from guids

### DIFF
--- a/jobs/clamav/templates/conf/clamd.conf.erb
+++ b/jobs/clamav/templates/conf/clamd.conf.erb
@@ -67,4 +67,5 @@ OnAccessMountPath /var/vcap/data
 OnAccessMountPath /var/vcap/store
 OnAccessDisableDDD false
 OnAccessPrevention false
+ExcludePath ^/var/vcap/data/packages/
 TemporaryDirectory /var/vcap/data/tmp


### PR DESCRIPTION
GUIDs in directories and autogenerated package compilation continues to cause false positive readings from ClamAV heuristic scans.