### PR TITLE
Replace riemann with prometheus

### DIFF
--- a/jobs/clamav/templates/bin/database_error.sh.erb
+++ b/jobs/clamav/templates/bin/database_error.sh.erb
@@ -5,7 +5,7 @@ tempfile=$(mktemp)
 
 cat <<DETECTION > ${tempfile}
 # HELP clamav_database_error_detected FreshClam database detection timestamp
-clamav_database_error_detected {hostname="`hostname`", error="Error updating virus definitions with FreshClam"} $(date +%s)
+clamav_database_error_detected {hostname="`hostname`", message="Error updating virus definitions with FreshClam"} $(date +%s)
 DETECTION
 
 mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-freshclam-database-error-detection.prom

--- a/jobs/clamav/templates/bin/database_error.sh.erb
+++ b/jobs/clamav/templates/bin/database_error.sh.erb
@@ -1,5 +1,13 @@
 #!/bin/sh
 
-/var/vcap/jobs/riemannc/bin/riemannc --host `hostname` --service "clamav" --state "critical" --description "Error updating virus definitions"
+# Write detection timestamp to prometheus
+tempfile=$(mktemp)
+
+cat <<DETECTION > ${tempfile}
+# HELP clamav_database_error_detected FreshClam database detection timestamp
+clamav_database_error_detected {hostname="`hostname`", error="Error updating virus definitions with FreshClam"} $(date +%s)
+DETECTION
+
+mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-freshclam-database-error-detection.prom
 
 rm /var/vcap/packages/clamav/database/defs_are_current

--- a/jobs/clamav/templates/bin/database_outdated.sh.erb
+++ b/jobs/clamav/templates/bin/database_outdated.sh.erb
@@ -1,5 +1,13 @@
 #!/bin/sh
 
-/var/vcap/jobs/riemannc/bin/riemannc --host `hostname` --service "clamav" --state "critical" --description "Virus definitions are out of date"
+# Write detection timestamp to prometheus
+tempfile=$(mktemp)
+
+cat <<DETECTION > ${tempfile}
+# HELP clamav_database_outdated_detected FreshClam database detection timestamp
+clamav_database_outdated_detected {hostname="`hostname`", error="Virus definitions are out of date with FreshClam"} $(date +%s)
+DETECTION
+
+mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-freshclam-database-outdated-detection.prom
 
 rm /var/vcap/packages/clamav/database/defs_are_current

--- a/jobs/clamav/templates/bin/database_outdated.sh.erb
+++ b/jobs/clamav/templates/bin/database_outdated.sh.erb
@@ -5,7 +5,7 @@ tempfile=$(mktemp)
 
 cat <<DETECTION > ${tempfile}
 # HELP clamav_database_outdated_detected FreshClam database detection timestamp
-clamav_database_outdated_detected {hostname="`hostname`", error="Virus definitions are out of date with FreshClam"} $(date +%s)
+clamav_database_outdated_detected {hostname="`hostname`", message="Virus definitions are out of date with FreshClam"} $(date +%s)
 DETECTION
 
 mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-freshclam-database-outdated-detection.prom

--- a/jobs/clamav/templates/bin/database_updated.sh.erb
+++ b/jobs/clamav/templates/bin/database_updated.sh.erb
@@ -1,3 +1,13 @@
 #!/bin/sh
 
+# Write detection timestamp to prometheus
+tempfile=$(mktemp)
+
+cat <<DETECTION > ${tempfile}
+# HELP clamav_database_updated_detected FreshClam database detection timestamp
+clamav_database_updated_detected {hostname="`hostname`", message="Successfully updated virus definitions with FreshClam"} $(date +%s)
+DETECTION
+
+mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-freshclam-database-updated-detection.prom
+
 touch /var/vcap/packages/clamav/database/defs_are_current

--- a/jobs/clamav/templates/bin/virus_detected.sh.erb
+++ b/jobs/clamav/templates/bin/virus_detected.sh.erb
@@ -1,3 +1,11 @@
 #!/bin/sh
 
-/var/vcap/jobs/riemannc/bin/riemannc --host `hostname` --service "clamav" --state "critical" --description "$CLAM_VIRUSEVENT_FILENAME has a virus called $CLAM_VIRUSEVENT_VIRUSNAME"
+# Write detection timestamp to prometheus
+tempfile=$(mktemp)
+
+cat <<DETECTION > ${tempfile}
+# HELP clamav_virus_detected ClamAV virus detection timestamp
+clamav_virus_detected {hostname="`hostname`", filename="${CLAM_VIRUSEVENT_FILENAME}", virusname="${CLAM_VIRUSEVENT_VIRUSNAME}"} $(date +%s)
+DETECTION
+
+mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-virus-detection.prom


### PR DESCRIPTION
Following along on how we do it across other releases and the prometheus docs for text-file collectors. Also we don't use riemann anymore, so having a call to that was causing these scripts to fail and monit to report unhealthy jobs for the `defs_are_current` job/file.

- https://github.com/search?q=user%3A18f+node_exporter&type=Code
- https://github.com/prometheus/node_exporter#textfile-collector