### PR TITLE
add service group to file check jobs

### DIFF
--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -14,7 +14,9 @@ check process freshclam
 check file clamav_defs_are_current with path /var/vcap/packages/clamav/database/defs_are_current
   if not exist then alert
   depends on freshclam
+  group vcap
 
 check file freshclam.log with path /var/vcap/sys/log/clamav/freshclam.log
   if timestamp > 2 hours then alert
   depends on freshclam
+  group vcap


### PR DESCRIPTION
This job fails and bosh ignores it because it's not part of the vcap group. This change tells bosh to care about these checks failing.

# Security considerations
This will better alert us about stale clamav definitions, improving our security posture.