### PR TITLE
only have one clamav

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,3 @@
-clamav/clamav-0.101.1.tar.gz:
-  size: 21691396
-  object_id: 7ae1d888-736a-45af-716b-103daa4f1905
-  sha: 7a62cce441383096b73c5e23b10d18bd6553b1e1
 clamav/clamav-0.102.1.tar.gz:
   size: 13215586
   object_id: fd71c94c-de98-4aa5-63d4-482ef1f382c0


### PR DESCRIPTION
including both blobs is very much confusing the packaging script, so I removed the old one.

# Security Considerations
None - this is a bugfix to allow the previous version bump to complete