### PR TITLE
Ignore log

### DIFF
--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -15,3 +15,8 @@ check file clamav_defs_are_current with path /var/vcap/packages/clamav/database/
   if timestamp > 2 hours then alert
   depends on freshclam
   group vcap
+
+check file freshclam.log with path /var/vcap/sys/log/clamav/freshclam.log
+  if timestamp > 2 hours then alert
+  depends on freshclam
+  group vcap

--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -12,6 +12,6 @@ check process freshclam
   group vcap
 
 check file clamav_defs_are_current with path /var/vcap/packages/clamav/database/defs_are_current
-  if timestamp > 2 hours then alert
+  if not exist then alert
   depends on freshclam
   group vcap

--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -12,6 +12,6 @@ check process freshclam
   group vcap
 
 check file clamav_defs_are_current with path /var/vcap/packages/clamav/database/defs_are_current
-  if not exist then alert
+  if timestamp > 2 hours then alert
   depends on freshclam
   group vcap

--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -15,8 +15,3 @@ check file clamav_defs_are_current with path /var/vcap/packages/clamav/database/
   if not exist then alert
   depends on freshclam
   group vcap
-
-check file freshclam.log with path /var/vcap/sys/log/clamav/freshclam.log
-  if timestamp > 2 hours then alert
-  depends on freshclam
-  group vcap

--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -15,8 +15,3 @@ check file clamav_defs_are_current with path /var/vcap/packages/clamav/database/
   if timestamp > 2 hours then alert
   depends on freshclam
   group vcap
-
-check file freshclam.log with path /var/vcap/sys/log/clamav/freshclam.log
-  if timestamp > 2 hours then alert
-  depends on freshclam
-  group vcap


### PR DESCRIPTION
with the last release, freshclam started adding dates to the logfile names, which causes the monit tests to fail.
As far as I can tell:
- there's no way to disable this
- there's no way to tell Monit to look for a glob/regex/set of files

This change stops monitoring the log file. The logfile check seems redundant, given the freshclam  process check

# security considerations
None