### PR TITLE
Data DB  move

### DIFF
--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -11,7 +11,7 @@ check process freshclam
   depends on clamd
   group vcap
 
-check file clamav_defs_are_current with path /var/vcap/packages/clamav/database/defs_are_current
+check file clamav_defs_are_current with path /var/vcap/data/clamav/database/defs_are_current
   if not exist then alert
   depends on freshclam
   group vcap

--- a/jobs/clamav/templates/bin/clamav_ctl.sh
+++ b/jobs/clamav/templates/bin/clamav_ctl.sh
@@ -3,6 +3,7 @@ export PKG_LOC=/var/vcap/packages/clamav
 
 LOG_DIR=/var/vcap/sys/log/clamav
 RUN_DIR=/var/vcap/sys/run/clamav
+DATADB_DIR=/var/vcap/data/clamav/database
 
 if [ ! -d "${LOG_DIR}" ]; then
 	mkdir -p ${LOG_DIR}
@@ -16,6 +17,9 @@ if [ ! -d "${RUN_DIR}" ]; then
 	mkdir -p ${RUN_DIR}
 fi
 
+if [ ! -d "${DATADB_DIR}" ]; then
+	mkdir -p ${DATADB_DIR}
+fi
 case "$1" in
 	'start_clamd')
 	  $PKG_LOC/sbin/clamd -c /var/vcap/jobs/clamav/conf/clamd.conf

--- a/jobs/clamav/templates/bin/clamav_ctl.sh
+++ b/jobs/clamav/templates/bin/clamav_ctl.sh
@@ -3,7 +3,6 @@ export PKG_LOC=/var/vcap/packages/clamav
 
 LOG_DIR=/var/vcap/sys/log/clamav
 RUN_DIR=/var/vcap/sys/run/clamav
-DATADB_DIR=/var/vcap/data/clamav/database
 
 if [ ! -d "${LOG_DIR}" ]; then
 	mkdir -p ${LOG_DIR}
@@ -17,9 +16,6 @@ if [ ! -d "${RUN_DIR}" ]; then
 	mkdir -p ${RUN_DIR}
 fi
 
-if [ ! -d "${DATADB_DIR}" ]; then
-	mkdir -p ${DATADB_DIR}
-fi
 case "$1" in
 	'start_clamd')
 	  $PKG_LOC/sbin/clamd -c /var/vcap/jobs/clamav/conf/clamd.conf

--- a/jobs/clamav/templates/bin/database_error.sh.erb
+++ b/jobs/clamav/templates/bin/database_error.sh.erb
@@ -10,4 +10,4 @@ DETECTION
 
 mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-freshclam-database-error-detection.prom
 
-rm /var/vcap/packages/clamav/database/defs_are_current
+rm /var/vcap/data/clamav/database/defs_are_current

--- a/jobs/clamav/templates/bin/database_outdated.sh.erb
+++ b/jobs/clamav/templates/bin/database_outdated.sh.erb
@@ -10,4 +10,4 @@ DETECTION
 
 mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-freshclam-database-outdated-detection.prom
 
-rm /var/vcap/packages/clamav/database/defs_are_current
+rm /var/vcap/data/clamav/database/defs_are_current

--- a/jobs/clamav/templates/bin/database_updated.sh.erb
+++ b/jobs/clamav/templates/bin/database_updated.sh.erb
@@ -10,4 +10,4 @@ DETECTION
 
 mv ${tempfile} /var/vcap/jobs/node_exporter/config/clamav-freshclam-database-updated-detection.prom
 
-touch /var/vcap/packages/clamav/database/defs_are_current
+touch /var/vcap/data/clamav/database/defs_are_current

--- a/jobs/clamav/templates/bin/pre-start.erb
+++ b/jobs/clamav/templates/bin/pre-start.erb
@@ -5,15 +5,15 @@ export HOUR=$(shuf -i <%= p('clamav.nightly.scan.start') %>-<%= p('clamav.nightl
 export CLAMAV_HOME=/var/vcap/packages/clamav
 export DATADB_DIR=/var/vcap/data/clamav/database
 
-#make database DIR if missing
+# make database DIR if missing
 if [ ! -d "${DATADB_DIR}" ]; then
 	mkdir -p ${DATADB_DIR}
 fi
 
-#check if there is an existing DB in data
+# check if there is an existing DB in data
 if [ -z "$(ls -A -- "${DATADB_DIR}")" ]; then
-  echo "Building out freshclam DB for the 1st time
-  $CLAMAV_HOME/bin/freshclam -u root --config-file $CLAMAV_HOME/conf/freshclam.conf
+  echo "Building out freshclam DB for the 1st time"
+  $CLAMAV_HOME/bin/freshclam -u root --config-file /var/vcap/jobs/clamav/conf/freshclam.conf
   # set the monit flag
   touch $CLAMAV_DATA/database/defs_are_current
 fi

--- a/jobs/clamav/templates/bin/pre-start.erb
+++ b/jobs/clamav/templates/bin/pre-start.erb
@@ -15,7 +15,7 @@ if [ -z "$(ls -A -- "${DATADB_DIR}")" ]; then
   echo "Building out freshclam DB for the 1st time"
   $CLAMAV_HOME/bin/freshclam -u root --config-file /var/vcap/jobs/clamav/conf/freshclam.conf
   # set the monit flag
-  touch $CLAMAV_DATA/database/defs_are_current
+  touch $DATADB_DIR/defs_are_current
 fi
 
 <% if_p("clamav.include_directories") do |indirs| %>

--- a/jobs/clamav/templates/bin/pre-start.erb
+++ b/jobs/clamav/templates/bin/pre-start.erb
@@ -2,6 +2,21 @@
 
 export MINUTE=$(expr $RANDOM % 60)
 export HOUR=$(shuf -i <%= p('clamav.nightly.scan.start') %>-<%= p('clamav.nightly.scan.stop') %> -n 1)
+export CLAMAV_HOME=/var/vcap/packages/clamav
+export DATADB_DIR=/var/vcap/data/clamav/database
+
+#make database DIR if missing
+if [ ! -d "${DATADB_DIR}" ]; then
+	mkdir -p ${DATADB_DIR}
+fi
+
+#check if there is an existing DB in data
+if [ -z "$(ls -A -- "${DATADB_DIR}")" ]; then
+  echo "Building out freshclam DB for the 1st time
+  $CLAMAV_HOME/bin/freshclam -u root --config-file $CLAMAV_HOME/conf/freshclam.conf
+  # set the monit flag
+  touch $CLAMAV_DATA/database/defs_are_current
+fi
 
 <% if_p("clamav.include_directories") do |indirs| %>
 <% indirs.each do |indir| %>

--- a/jobs/clamav/templates/conf/clamd.conf.erb
+++ b/jobs/clamav/templates/conf/clamd.conf.erb
@@ -5,7 +5,7 @@ LogSyslog true
 LogRotate true
 ExtendedDetectionInfo true
 PidFile /var/vcap/sys/run/clamav/clamd.pid
-DatabaseDirectory /var/vcap/packages/clamav/database
+DatabaseDirectory /var/vcap/data/clamav/database
 LocalSocket /var/vcap/sys/run/clamav/clamd.ctl
 MaxConnectionQueueLength 15
 MaxThreads 12

--- a/jobs/clamav/templates/conf/freshclam.conf.erb
+++ b/jobs/clamav/templates/conf/freshclam.conf.erb
@@ -1,5 +1,5 @@
 # disable log rotation since it's currently broken - freshclam currently rotates the log file,
-# then writes to the rotated file, so in either case, the file grows without bounds, but 
+# then writes to the rotated file, so in either case, the file grows without bounds, but
 # with rotation enabled, monit gets confused
 #LogFileMaxSize 1M
 LogRotate false
@@ -8,7 +8,7 @@ LogSyslog true
 LogFacility LOG_LOCAL6
 LogVerbose false
 PidFile /var/vcap/sys/run/clamav/freshclam.pid
-DatabaseDirectory /var/vcap/packages/clamav/database
+DatabaseDirectory /var/vcap/data/clamav/database
 Foreground false
 UpdateLogFile /var/vcap/sys/log/clamav/freshclam.log
 DatabaseOwner root

--- a/packages/clamav/packaging
+++ b/packages/clamav/packaging
@@ -1,11 +1,13 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 mkdir -p /var/vcap/packages/clamav
+mkdir -p /var/vcap/data/clamav
 # Available variables
 # $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 export CLAMAV_HOME=/var/vcap/packages/clamav
+export CLAMAV_DATA=/var/vcap/data/clamav
 export COMPILE_HOME=`pwd`
 
 tar xvzf clamav/clamav*.tar.gz
@@ -15,13 +17,13 @@ make
 make install
 
 # do an initial sync of the virus definition at compile time
-mkdir -p $CLAMAV_HOME/database
+mkdir -p $CLAMAV_DATA/database
 
 TMPCONF=$(mktemp)
 
 # minimum configuration required to do a db sync
 cat << EOF > $TMPCONF
-DatabaseDirectory $CLAMAV_HOME/database
+DatabaseDirectory $CLAMAV_DATA/database
 DatabaseMirror db.us.clamav.net
 DatabaseMirror database.clamav.net
 EOF
@@ -30,7 +32,7 @@ EOF
 $CLAMAV_HOME/bin/freshclam -u root --config-file $TMPCONF
 
 # set the monit flag
-touch $CLAMAV_HOME/database/defs_are_current
+touch $CLAMAV_DATA/database/defs_are_current
 
 rm $TMPCONF
 


### PR DESCRIPTION
## Changes proposed in this pull request:

-  Move clamav db directory out of /var/vcap/packages where updates triggered aide to under /var/vcap/data

## Security considerations

The release does not include a default/baseline fresh clam DB in the blob since /var/vcap/data is not bundled in the compiled blob so first time run on new release/new stemcell will do a full freshclam db download.
