### PR TITLE
don't check on freshclam for now

### DIFF
--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -11,10 +11,10 @@ check process freshclam
   depends on clamd
   group vcap
 
-check file clamav_defs_are_current with path /var/vcap/data/clamav/database/defs_are_current
-  if not exist then alert
-  depends on freshclam
-  group vcap
+#check file clamav_defs_are_current with path /var/vcap/data/clamav/database/defs_are_current
+#  if not exist then alert
+#  depends on freshclam
+#  group vcap
 
 <% if p("clamav.on_access_enabled") == true %>
 check process clamavonaccess


### PR DESCRIPTION
## Changes proposed in this pull request:

-  don't check on freshclam for now


## Security considerations

This is bad long term, because it means virus definitions could go outdated without us knowing, but it is a temporary change to resolve production issues