### PR TITLE
make freshclam monitoring optional

### DIFF
--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -11,10 +11,12 @@ check process freshclam
   depends on clamd
   group vcap
 
-#check file clamav_defs_are_current with path /var/vcap/data/clamav/database/defs_are_current
-#  if not exist then alert
-#  depends on freshclam
-#  group vcap
+<% if p("clamav.alert_on_stale_defs") == true %>
+check file clamav_defs_are_current with path /var/vcap/data/clamav/database/defs_are_current
+  if not exist then alert
+  depends on freshclam
+  group vcap
+<% end %>
 
 <% if p("clamav.on_access_enabled") == true %>
 check process clamavonaccess

--- a/jobs/clamav/spec
+++ b/jobs/clamav/spec
@@ -51,3 +51,6 @@ properties:
     description: "Additional ClamAV options to be added to clamd.conf - yml array"
     example: |
       - OnAccessExcludePath /var/vcap/packages/clamd
+  clamav.alert_on_stale_defs:
+    description: "Use monit to alert about database update failures"
+    default: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- make freshclam monitoring optional


## Security considerations

monitoring our antivirus is better security than not