### PR TITLE
coerce bools to strings

### DIFF
--- a/jobs/clamav/monit
+++ b/jobs/clamav/monit
@@ -11,14 +11,14 @@ check process freshclam
   depends on clamd
   group vcap
 
-<% if p("clamav.alert_on_stale_defs") == true %>
+<% if p("clamav.alert_on_stale_defs").to_s == "true" %>
 check file clamav_defs_are_current with path /var/vcap/data/clamav/database/defs_are_current
   if not exist then alert
   depends on freshclam
   group vcap
 <% end %>
 
-<% if p("clamav.on_access_enabled") == true %>
+<% if p("clamav.on_access_enabled").to_s == "true" %>
 check process clamavonaccess
   matching "clamonacc"
   start program "/var/vcap/jobs/clamav/bin/clamav_ctl.sh start_clamavonaccess" with timeout 500 seconds

--- a/jobs/clamav/templates/bin/pre-start.erb
+++ b/jobs/clamav/templates/bin/pre-start.erb
@@ -27,7 +27,7 @@ export FULLSCANDIRS="-m $SCANDIRS"
 
 echo "Pre-start started"
 
-<% if p("clamav.schedule_enabled") == true %>
+<% if p("clamav.schedule_enabled").to_s == "true" %>
 
   echo "Processing ClamAV scheduling options"
 


### PR DESCRIPTION
because we have several layers of yaml, templating, and interpolation going on with manifests, runtime config, bosh vars files, credhub, etc, sometimes our bools are ending up as strings. If we coerce whatever our variables are into strings, we know they'll always be strings and we can compare them as such.

## Changes proposed in this pull request:

- convert booleans to strings before comparing to properties

## Security considerations

None