### PR TITLE
Adjust CPU Usage for clamdshed

### DIFF
--- a/jobs/clamav/spec
+++ b/jobs/clamav/spec
@@ -26,6 +26,9 @@ properties:
   clamav.dbMirror2:
     description: "Secondary virus definition update host"
     default: database.clamav.net
+  clamav.maxthreads:
+    description: "Max number of threads clamd will use. Each thread can take a whole CPU"
+    default: 2
   clamav.on_access_enabled:
     description: "Enable on-access scanning with ClamAV"
     default: false

--- a/jobs/clamav/templates/conf/clamd.conf.erb
+++ b/jobs/clamav/templates/conf/clamd.conf.erb
@@ -8,7 +8,7 @@ PidFile /var/vcap/sys/run/clamav/clamd.pid
 DatabaseDirectory /var/vcap/data/clamav/database
 LocalSocket /var/vcap/sys/run/clamav/clamd.ctl
 MaxConnectionQueueLength 15
-MaxThreads 12
+MaxThreads <%= properties.clamav.maxthreads %>
 ReadTimeout 180
 CommandReadTimeout 5
 SendBufTimeout 200

--- a/jobs/clamav/templates/conf/clamdsched.erb
+++ b/jobs/clamav/templates/conf/clamdsched.erb
@@ -1,2 +1,2 @@
 # ClamAV schedule scan cron.d entry
-temp_time root /var/vcap/packages/clamav/bin/clamdscan --config-file=/var/vcap/jobs/clamav/conf/clamd.conf --log=/var/vcap/sys/log/clamav/sched.log -m temp_holder
+temp_time nice -15 root /var/vcap/packages/clamav/bin/clamdscan --config-file=/var/vcap/jobs/clamav/conf/clamd.conf --log=/var/vcap/sys/log/clamav/sched.log -m temp_holder

--- a/jobs/clamav/templates/conf/clamdsched.erb
+++ b/jobs/clamav/templates/conf/clamdsched.erb
@@ -1,2 +1,2 @@
 # ClamAV schedule scan cron.d entry
-temp_time nice -15 root /var/vcap/packages/clamav/bin/clamdscan --config-file=/var/vcap/jobs/clamav/conf/clamd.conf --log=/var/vcap/sys/log/clamav/sched.log -m temp_holder
+temp_time root  nice -15 /var/vcap/packages/clamav/bin/clamdscan --config-file=/var/vcap/jobs/clamav/conf/clamd.conf --log=/var/vcap/sys/log/clamav/sched.log -m temp_holder


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adjust number of default thread used
- Set `nice` on cron sched as to not consume all CPU

## Security considerations

Running AV on the platform insures we are free of viruses and malware.
