### PR TITLE
Remove duplicate scheduled scan locations

### DIFF
--- a/jobs/clamav/templates/bin/pre-start.erb
+++ b/jobs/clamav/templates/bin/pre-start.erb
@@ -24,7 +24,7 @@ echo "Pre-start started"
     <% indirs.each do |indir| %>
     export SCANDIRS="<%= indir %> $SCANDIRS"
     <% end %>
-    export FULLSCANDIRS="-m /var/vcap/jobs /var/vcap/data /var/vcap/store /var/vcap/packages $SCANDIRS"
+    export FULLSCANDIRS="-m $SCANDIRS"
   <% end %>
 
   export MINUTE=$(expr $RANDOM % 60)


### PR DESCRIPTION
## Changes proposed in this pull request:

- Found during the Annual Assessment that the clamdscan cron job was scanning the same set of four folders twice.  The first set of four folders is hard coded, the second set relies on a credhub value defined as `clamav_include_directories` that also has the same four folders
- Ticket: https://github.com/cloud-gov/private/issues/1337
- Merging to `main` branch this time
- Manual removal of the second set of folders showed during testing that the scan time was cut in half (44s to 22s on a random dev vm):

```
--------------------------------------
/var/vcap/jobs: OK
/var/vcap/data: OK
/var/vcap/store: OK
/var/vcap/packages: OK
/var/vcap/store: OK
/var/vcap/data: OK
/var/vcap/packages: OK
/var/vcap/jobs: OK

----------- SCAN SUMMARY -----------
Infected files: 0
Time: 44.344 sec (0 m 44 s)
Start Date: 2024:07:01 20:03:24
End Date:   2024:07:01 20:04:08

--------------------------------------
/var/vcap/jobs: OK
/var/vcap/data: OK
/var/vcap/store: OK
/var/vcap/packages: OK

----------- SCAN SUMMARY -----------
Infected files: 0
Time: 22.922 sec (0 m 22 s)
Start Date: 2024:07:01 20:05:12
End Date:   2024:07:01 20:05:35
```
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just a configuration change
